### PR TITLE
Fix NPE with Path.getFileName()

### DIFF
--- a/src/main/java/org/cadixdev/mercury/Mercury.java
+++ b/src/main/java/org/cadixdev/mercury/Mercury.java
@@ -174,6 +174,7 @@ public final class Mercury {
 
         // Walk directory to find source files
         String[] sourceFiles = toArray(Files.walk(this.sourceDir)
+                .filter(path -> path.getFileName() != null)
                 .filter(p -> p.getFileName().toString().endsWith(JAVA_EXTENSION)));
 
         for (SourceProcessor processor : this.processors) {

--- a/src/main/java/org/cadixdev/mercury/Mercury.java
+++ b/src/main/java/org/cadixdev/mercury/Mercury.java
@@ -174,8 +174,7 @@ public final class Mercury {
 
         // Walk directory to find source files
         String[] sourceFiles = toArray(Files.walk(this.sourceDir)
-                .filter(path -> path.getFileName() != null)
-                .filter(p -> p.getFileName().toString().endsWith(JAVA_EXTENSION)));
+                .filter(p -> p.getFileName() != null && p.getFileName().toString().endsWith(JAVA_EXTENSION)));
 
         for (SourceProcessor processor : this.processors) {
             processor.initialize(this);


### PR DESCRIPTION
Path.getFileName() can be null, thus casuing a NPE when Mercury is walking the files.

I discoverved this when trying to use an NIO [zip file system](https://docs.oracle.com/javase/7/docs/technotes/guides/io/fsp/zipfilesystemprovider.html) as the source input.