### PR TITLE
Update Lorenz to 0.6.0-SNAPSHOT

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -32,7 +32,7 @@ dependencies {
 
     // TODO: Split in separate modules
     api("org.cadixdev:at:0.1.0-SNAPSHOT")
-    api("org.cadixdev:lorenz:0.5.2")
+    api("org.cadixdev:lorenz:0.6.0-SNAPSHOT")
 
     "jdt"("$jdt:sources")
 


### PR DESCRIPTION
to fix version mismatch issues when using Mercury and Lorenz 0.6.0-SNAPSHOT in the same project.