### PR TITLE
Don't mark local classes public

### DIFF
--- a/src/main/java/org/cadixdev/mercury/remapper/RemapperVisitor.java
+++ b/src/main/java/org/cadixdev/mercury/remapper/RemapperVisitor.java
@@ -131,14 +131,15 @@ class RemapperVisitor extends SimpleRemapperVisitor {
     }
 
     private void remapInnerType(QualifiedName qualifiedName, ITypeBinding outerClass) {
-        if (outerClass.getBinaryName() == null) {
+        final String binaryName = outerClass.getBinaryName();
+        if (binaryName == null) {
             if (this.context.getMercury().isGracefulClasspathChecks()) {
                 return;
             }
             throw new IllegalStateException("No binary name for " + outerClass.getQualifiedName());
         }
 
-        ClassMapping<?, ?> outerClassMapping = this.mappings.computeClassMapping(outerClass.getBinaryName()).orElse(null);
+        ClassMapping<?, ?> outerClassMapping = this.mappings.computeClassMapping(binaryName).orElse(null);
         if (outerClassMapping == null) {
             return;
         }


### PR DESCRIPTION
The AT generator can get confused if local classes are in a mapped class
and that local class isn't mapped, since it's package won't match the
containing class's package. This is illegal as local classes can't be
public. Local class access should never need to be transformed though,
so we can safely ignore local classe.