### PR TITLE
Graceful Javadoc remapping

### DIFF
--- a/src/main/java/org/cadixdev/mercury/Mercury.java
+++ b/src/main/java/org/cadixdev/mercury/Mercury.java
@@ -47,6 +47,11 @@ public final class Mercury {
      * gracefully.
      */
     private boolean gracefulClasspathChecks = false;
+    /**
+     * See {@link #gracefulClasspathChecks}. This is just for Javadoc as they can be
+     * broken, but we want to ignore
+     */
+    private boolean gracefulJavadocClasspathChecks = false;
 
     private final List<Path> classPath = new ArrayList<>();
     private final List<Path> sourcePath = new ArrayList<>();
@@ -81,6 +86,14 @@ public final class Mercury {
 
     public void setGracefulClasspathChecks(final boolean enable) {
         this.gracefulClasspathChecks = enable;
+    }
+
+    public boolean isGracefulJavadocClasspathChecks() {
+        return gracefulJavadocClasspathChecks;
+    }
+
+    public void setGracefulJavadocClasspathChecks(boolean enable) {
+        this.gracefulJavadocClasspathChecks = enable;
     }
 
     public List<Path> getClassPath() {

--- a/src/main/java/org/cadixdev/mercury/remapper/RemapperVisitor.java
+++ b/src/main/java/org/cadixdev/mercury/remapper/RemapperVisitor.java
@@ -111,7 +111,7 @@ class RemapperVisitor extends SimpleRemapperVisitor {
     private void remapQualifiedType(QualifiedName node, ITypeBinding binding) {
         String binaryName = binding.getBinaryName();
         if (binaryName == null) {
-            if (this.context.getMercury().isGracefulClasspathChecks()) {
+            if (this.context.getMercury().isGracefulClasspathChecks() || this.context.getMercury().isGracefulJavadocClasspathChecks() && GracefulCheck.isJavadoc(node)) {
                 return;
             }
             throw new IllegalStateException("No binary name for " + binding.getQualifiedName());

--- a/src/main/java/org/cadixdev/mercury/util/GracefulCheck.java
+++ b/src/main/java/org/cadixdev/mercury/util/GracefulCheck.java
@@ -11,7 +11,9 @@
 package org.cadixdev.mercury.util;
 
 import org.cadixdev.mercury.SourceContext;
+import org.eclipse.jdt.core.dom.ASTNode;
 import org.eclipse.jdt.core.dom.ITypeBinding;
+import org.eclipse.jdt.core.dom.Javadoc;
 
 /**
  * Utility for checking gracefully, based on configuration.
@@ -22,6 +24,16 @@ public final class GracefulCheck {
 
     public static boolean checkGracefully(final SourceContext ctx, final ITypeBinding binding) {
         return ctx.getMercury().isGracefulClasspathChecks() && binding.getBinaryName() == null;
+    }
+
+    public static boolean isJavadoc(ASTNode node) {
+        for (ASTNode current = node; current != null; current = current.getParent()) {
+            if (current instanceof Javadoc) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     private GracefulCheck() {


### PR DESCRIPTION
Looks like invalid members don't cause a crash