### PR TITLE
Fix overlapping MultiTextEdits causing conflicts

### DIFF
--- a/src/main/java/org/cadixdev/mercury/RewriteContext.java
+++ b/src/main/java/org/cadixdev/mercury/RewriteContext.java
@@ -96,7 +96,12 @@ public final class RewriteContext extends SourceContext {
             return edit;
         }
         if (edit != null) {
-            before.addChild(edit);
+            if (edit instanceof MultiTextEdit) {
+                MultiTextEdit multiTextEdit = (MultiTextEdit) edit;
+                before.addChildren(multiTextEdit.removeChildren());
+            } else {
+                before.addChild(edit);
+            }
         }
         return before;
     }

--- a/src/test/java/org/cadixdev/mercury/test/RemappingTests.java
+++ b/src/test/java/org/cadixdev/mercury/test/RemappingTests.java
@@ -47,6 +47,7 @@ class RemappingTests {
     // 3. Eclipse Bugs
     //      - https://bugs.eclipse.org/bugs/show_bug.cgi?id=511958 (currently disabled)
     //      - https://bugs.eclipse.org/bugs/show_bug.cgi?id=564263 (currently disabled)
+    // 4. Import remapping tests (GH-28)
 
     @Test
     void remap() throws Exception {
@@ -66,6 +67,11 @@ class RemappingTests {
         // - Test 3
         //this.copy(in, "eclipse/X.java");
         //this.copy(in, "eclipse/Test.java");
+        // - Test 4
+        this.copy(in, "com/example/ImportTest.java");
+        this.copy(in, "com/example/other/AnotherClass.java");
+        this.copy(in, "com/example/other/OtherClass.java");
+        this.copy(in, "com/example/pkg/Constants.java");
 
         // Load our test mappings
         final MappingSet mappings = MappingSet.create();
@@ -89,6 +95,11 @@ class RemappingTests {
         // - Test 3
         //this.verify(out, "eclipse/X.java");
         //this.verify(out, "eclipse/Test.java");
+        // - Test 4
+        this.verify(out, "net/example/ImportTestNew.java");
+        this.verify(out, "net/example/newother/AnotherClass.java");
+        this.verify(out, "net/example/newother/OtherClass.java");
+        this.verify(out, "net/example/pkg/Util.java");
 
         // Delete the directory
         Files.walk(tempDir)

--- a/src/test/resources/a/com/example/ImportTest.java
+++ b/src/test/resources/a/com/example/ImportTest.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2018 Cadix Development (https://www.cadixdev.org)
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which accompanies this distribution,
+ * and is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package com.example;
+
+import com.example.other.AnotherClass;
+import static com.example.pkg.Constants.*;
+import com.example.other.OtherClass;
+import java.lang.String;
+import java.lang.Exception;
+
+public class ImportTest {
+
+    public void test() {
+        OtherClass otherClass = new OtherClass();
+        AnotherClass anotherClass = new AnotherClass();
+    }
+
+}

--- a/src/test/resources/a/com/example/other/AnotherClass.java
+++ b/src/test/resources/a/com/example/other/AnotherClass.java
@@ -1,0 +1,15 @@
+/*
+ * Copyright (c) 2018 Cadix Development (https://www.cadixdev.org)
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which accompanies this distribution,
+ * and is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package com.example.other;
+
+public class AnotherClass {
+
+}

--- a/src/test/resources/a/com/example/other/OtherClass.java
+++ b/src/test/resources/a/com/example/other/OtherClass.java
@@ -1,0 +1,15 @@
+/*
+ * Copyright (c) 2018 Cadix Development (https://www.cadixdev.org)
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which accompanies this distribution,
+ * and is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package com.example.other;
+
+public class OtherClass {
+
+}

--- a/src/test/resources/a/com/example/pkg/Constants.java
+++ b/src/test/resources/a/com/example/pkg/Constants.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright (c) 2018 Cadix Development (https://www.cadixdev.org)
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which accompanies this distribution,
+ * and is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package com.example.pkg;
+
+public class Constants {
+
+    public static final String NAME = "George";
+    public static final String BIRTHDAY = "June 1st";
+    public static final String VERSION = "1";
+
+}

--- a/src/test/resources/b/net/example/ImportTestNew.java
+++ b/src/test/resources/b/net/example/ImportTestNew.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2018 Cadix Development (https://www.cadixdev.org)
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which accompanies this distribution,
+ * and is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package net.example;
+
+import static net.example.pkg.Util.*;
+
+import java.lang.String;
+import net.example.newother.AnotherClass;
+import net.example.newother.OtherClass;
+import java.lang.Exception;
+
+public class ImportTestNew {
+
+    public void test() {
+        OtherClass otherClass = new OtherClass();
+        AnotherClass anotherClass = new AnotherClass();
+    }
+
+}

--- a/src/test/resources/b/net/example/newother/AnotherClass.java
+++ b/src/test/resources/b/net/example/newother/AnotherClass.java
@@ -1,0 +1,15 @@
+/*
+ * Copyright (c) 2018 Cadix Development (https://www.cadixdev.org)
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which accompanies this distribution,
+ * and is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package net.example.newother;
+
+public class AnotherClass {
+
+}

--- a/src/test/resources/b/net/example/newother/OtherClass.java
+++ b/src/test/resources/b/net/example/newother/OtherClass.java
@@ -1,0 +1,15 @@
+/*
+ * Copyright (c) 2018 Cadix Development (https://www.cadixdev.org)
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which accompanies this distribution,
+ * and is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package net.example.newother;
+
+public class OtherClass {
+
+}

--- a/src/test/resources/b/net/example/pkg/Util.java
+++ b/src/test/resources/b/net/example/pkg/Util.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright (c) 2018 Cadix Development (https://www.cadixdev.org)
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which accompanies this distribution,
+ * and is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package net.example.pkg;
+
+public class Util {
+
+    public static final String NAME = "George";
+    public static final String BIRTHDAY = "June 1st";
+    public static final String VERSION = "1";
+
+}

--- a/src/test/resources/test.tsrg
+++ b/src/test/resources/test.tsrg
@@ -14,3 +14,9 @@ eclipse/X eclipse/X
 	text message
 eclipse/Test eclipse/Test
 	text message
+
+# Test 4. Import tests
+com/example/pkg/Constants net/example/pkg/Util
+com/example/ImportTest net/example/ImportTestNew
+com/example/other/OtherClass net/example/newother/OtherClass
+com/example/other/AnotherClass net/example/newother/AnotherClass


### PR DESCRIPTION
This takes all of the children in the `MutliTextEdit` we want to merge and makes
them children of the `MutliTextEdit` being merged into. Conflicts were occurring
when one MTE's edit range was overlapping with the others edit range.

I ran this over multiple codebases and this change didn't affect anything other
than the static imports that were failing.