### PR TITLE
Fix bug causing all ATs to apply a `final` modifier

### DIFF
--- a/src/main/java/org/cadixdev/mercury/at/AccessTransformerRewriter.java
+++ b/src/main/java/org/cadixdev/mercury/at/AccessTransformerRewriter.java
@@ -115,7 +115,7 @@ public final class AccessTransformerRewriter implements SourceRewriter {
                         switch (finalChange) {
                             case REMOVE:
                                 this.context.createASTRewrite().remove(m, null);
-                                continue;
+                                // fallthrough
                             case ADD:
                                 finalChange = ModifierChange.NONE;
                                 continue;


### PR DESCRIPTION
The `finalChange` field wasn't getting reset like it needed to for the
REMOVE case, so this change lets it fallthrough to the ADD case to
reset.