### PR TITLE
Handle more cases when anonymous classes are remapped

### DIFF
--- a/src/test/java/org/cadixdev/mercury/test/RemappingTests.java
+++ b/src/test/java/org/cadixdev/mercury/test/RemappingTests.java
@@ -47,6 +47,9 @@ class RemappingTests {
     // 3. Eclipse Bugs
     //      - https://bugs.eclipse.org/bugs/show_bug.cgi?id=511958 (currently disabled)
     //      - https://bugs.eclipse.org/bugs/show_bug.cgi?id=564263 (currently disabled)
+    // 4. Anonymous class remapping
+    //    This test verifies we can handle remapping cases for different anonymous class remapping
+    //    combinations (GH-31).
 
     @Test
     void remap() throws Exception {
@@ -66,6 +69,8 @@ class RemappingTests {
         // - Test 3
         //this.copy(in, "eclipse/X.java");
         //this.copy(in, "eclipse/Test.java");
+        // - Test 4
+        this.copy(in, "anon/Test.java");
 
         // Load our test mappings
         final MappingSet mappings = MappingSet.create();
@@ -89,6 +94,8 @@ class RemappingTests {
         // - Test 3
         //this.verify(out, "eclipse/X.java");
         //this.verify(out, "eclipse/Test.java");
+        // - Test 4
+        this.verify(out, "anon/Anon.java");
 
         // Delete the directory
         Files.walk(tempDir)

--- a/src/test/resources/a/anon/Test.java
+++ b/src/test/resources/a/anon/Test.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2018 Cadix Development (https://www.cadixdev.org)
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which accompanies this distribution,
+ * and is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package anon;
+
+public class Test {
+    public void testMethod() {
+        new Object() { // Test$1 - this is the normal case
+            public void name(int first, int second) {}
+            public int field; // This comes from Test$2
+        };
+        new Object() { // Test$2 - here we match based on Test$3 (what this class maps to)
+            public void name(boolean first, boolean second) {}
+        };
+        new Object() { // Test$3 - here we match based on Test$2 (which this class maps from)
+            public void name(double first, double second) {}
+        };
+    }
+}

--- a/src/test/resources/b/anon/Anon.java
+++ b/src/test/resources/b/anon/Anon.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2018 Cadix Development (https://www.cadixdev.org)
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which accompanies this distribution,
+ * and is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package anon;
+
+public class Anon {
+    public void testMethod() {
+        new Object() { // Test$1 - this is the normal case
+            public void remapped(int first, int second) {}
+            public int abc; // This comes from Test$2
+        };
+        new Object() { // Test$2 - here we match based on Test$3 (what this class maps to)
+            public void remapped(boolean first, boolean second) {}
+        };
+        new Object() { // Test$3 - here we match based on Test$2 (which this class maps from)
+            public void remapped(double first, double second) {}
+        };
+    }
+}

--- a/src/test/resources/test.tsrg
+++ b/src/test/resources/test.tsrg
@@ -14,3 +14,13 @@ eclipse/X eclipse/X
 	text message
 eclipse/Test eclipse/Test
 	text message
+
+# Test 4. Anonymous class remap
+anon/Test anon/Anon
+anon/Test$1 anon/Anon$3
+	name (II)V remapped
+anon/Test$2 anon/Anon$1
+	name (DD)V remapped
+	field abc
+anon/Test$3 anon/Anon$2
+	name (ZZ)V remapped


### PR DESCRIPTION
In Java bytecode anonymous classes really aren't any different than any
other class, except for a few minor details. These differences don't
matter at all to the remapping process. `SomeClass$1` could be remapped
to `SomeClass$200` or even `SomeClass$AnotherClass` and it would
decompile the same, since in bytecode these are just class references.
In source code however, anonymous class naming is _very_ important and
isn't nearly as flexible. They are generated by the compiler based on
their location in the source file, which makes them very fragile to
changes.

For bytecode remapping this isn't an issue, but we do need to worry
about this for source code remapping. When this mapping comes along:

    net/minecraft/SomeClass$1 -> net/minecraft/SomeClass$10

It's actually rather unclear what that even means from a source code
perspective, and handling that remapping case is unclear. This commit
attempts to address this by being a little more flexible when remapping
members of anonymous classes by doing the following:

 1. First, check for the member signature in the class the member is in
 2. If the first check fails, check if the member is inside an anonymous
    class. If not, skip to step 5.
 3. Look for a sibling class of the original class whose obfuscated name
    matches our original class's deobfuscated name. If found, check for
    the member signature there.
 4. If that doesn't work, look for a sibling class of the original class
    whose deobfuscated name matches our original class's obfuscated
    name. If found, check for the member signature there.
 5. If none of those checks work, complete the original class's mappings
    with the inheritanceProvider and check one final time.

A few notes to point out:

 * This probably won't cover every case, but in my testing checking both
   3. and 4. finds every case successfully. We may need to revisit this
   if a situation comes up where those 2 checks aren't enough.
 * When referring to the class's obfuscated and deobfuscated names, I'm
   just referring to the numeric name. That is, for `SomeClass$1`, the
   name that I'm referring to here is just the `1`.