### PR TITLE
remapper: Correct handling of several qualified type variants

### DIFF
--- a/src/test/java/org/cadixdev/mercury/test/RemappingTests.java
+++ b/src/test/java/org/cadixdev/mercury/test/RemappingTests.java
@@ -59,7 +59,9 @@ class RemappingTests {
         // Copy our test classes to the temporary directory
         // - Test 1
         this.copy(in, "test/ObfClass.java");
+        this.copy(in, "NonNull.java");
         this.copy(in, "JavadocTest.java");
+        this.copy(in, "NameQualifiedTest.java");
         // - Test 2
         //this.copy(in, "OverrideChild.java");
         //this.copy(in, "OverrideParent.java");
@@ -83,6 +85,7 @@ class RemappingTests {
         // - Test 1
         this.verify(out, "Core.java");
         this.verify(out, "JavadocTest.java");
+        this.verify(out, "NameQualifiedTest.java");
         // - Test 2
         //this.verify(out, "OverrideChild.java");
         //this.verify(out, "OverrideParent.java");

--- a/src/test/resources/a/NameQualifiedTest.java
+++ b/src/test/resources/a/NameQualifiedTest.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2018 Cadix Development (https://www.cadixdev.org)
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which accompanies this distribution,
+ * and is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+import java.util.jar.Attributes;
+
+public abstract class NameQualifiedTest {
+
+  public abstract void testQualifiedToUnqualified(final test.@NonNull ObfClass clazz);
+
+  public abstract void testInnerClass(final Attributes.@NonNull Name name);
+
+  public abstract void testQualifiedInner(final java.nio.file.WatchEvent.@NonNull Kind<?> event)
+
+  public abstract void testFullyQualifed(final java.net.@NonNull URL url);
+
+}

--- a/src/test/resources/a/NonNull.java
+++ b/src/test/resources/a/NonNull.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) 2018 Cadix Development (https://www.cadixdev.org)
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which accompanies this distribution,
+ * and is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.CLASS)
+@Target({ElementType.TYPE_USE, ElementType.FIELD, ElementType.PARAMETER})
+public @interface NonNull {
+
+}
+

--- a/src/test/resources/b/NameQualifiedTest.java
+++ b/src/test/resources/b/NameQualifiedTest.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2018 Cadix Development (https://www.cadixdev.org)
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which accompanies this distribution,
+ * and is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+import java.util.jar.Attributes;
+
+public abstract class NameQualifiedTest {
+
+  public abstract void testQualifiedToUnqualified(final @NonNull Core clazz);
+
+  public abstract void testInnerClass(final Attributes.@NonNull Name name);
+
+  public abstract void testQualifiedInner(final java.nio.file.WatchEvent.@NonNull Kind<?> event)
+
+  public abstract void testFullyQualifed(final java.net.@NonNull URL url);
+
+}

--- a/src/test/resources/b/NonNull.java
+++ b/src/test/resources/b/NonNull.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright (c) 2018 Cadix Development (https://www.cadixdev.org)
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which accompanies this distribution,
+ * and is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.CLASS)
+@Target({ElementType.TYPE_USE, ElementType.FIELD, ElementType.PARAMETER})
+public @interface NonNull {
+
+}


### PR DESCRIPTION
This resolves the issues I had remapping qualified types in [Adventure](https://github.com/KyoriPowered/adventure-platform-fabric/blob/master/src/main/java/net/kyori/adventure/platform/fabric/impl/AbstractBossBarListener.java#L86).

The implementation does feel a little clunky to me, though that may just be because there are a few different cases that need covering. Let me know if you'd like it broken up differently.

I've also modified `remapType` to exclude qualified types from having imports added. The change I've made works for the specific cases tested, but I'm not sure of any larger impacts it may have.

This is an expanded version of the original patch by @ramidzkh.