### PR TITLE
Adjust local variable names if param mappings conflict + other fixes

### DIFF
--- a/src/main/java/org/cadixdev/mercury/Mercury.java
+++ b/src/main/java/org/cadixdev/mercury/Mercury.java
@@ -52,6 +52,11 @@ public final class Mercury {
      * broken, but we want to ignore
      */
     private boolean gracefulJavadocClasspathChecks = false;
+    /**
+     * Mercury will try different combinations of anonymous class indexes when searching
+     * for member mappings if this is true.
+     */
+    private boolean flexibleAnonymousClassMemberLookups = false;
 
     private final List<Path> classPath = new ArrayList<>();
     private final List<Path> sourcePath = new ArrayList<>();
@@ -94,6 +99,14 @@ public final class Mercury {
 
     public void setGracefulJavadocClasspathChecks(final boolean enable) {
         this.gracefulJavadocClasspathChecks = enable;
+    }
+
+    public boolean isFlexibleAnonymousClassMemberLookups() {
+        return this.flexibleAnonymousClassMemberLookups;
+    }
+
+    public void setFlexibleAnonymousClassMemberLookups(final boolean enable) {
+        this.flexibleAnonymousClassMemberLookups = enable;
     }
 
     public List<Path> getClassPath() {

--- a/src/main/java/org/cadixdev/mercury/remapper/RemapperVisitor.java
+++ b/src/main/java/org/cadixdev/mercury/remapper/RemapperVisitor.java
@@ -344,7 +344,7 @@ class RemapperVisitor extends SimpleRemapperVisitor {
                 }
             }
 
-            ClassMapping<?, ?> mapping = this.mappings.getClassMapping(inner.getBinaryName()).orElse(null);
+            ClassMapping<?, ?> mapping = this.mappings.computeClassMapping(inner.getBinaryName()).orElse(null);
 
             if (isPackagePrivate(modifiers)) {
                 // Must come from the same package

--- a/src/main/java/org/cadixdev/mercury/remapper/RemapperVisitor.java
+++ b/src/main/java/org/cadixdev/mercury/remapper/RemapperVisitor.java
@@ -271,7 +271,6 @@ class RemapperVisitor extends SimpleRemapperVisitor {
         return false;
     }
 
-
     @Override
     public boolean visit(PackageDeclaration node) {
         String currentPackage = node.getName().getFullyQualifiedName();
@@ -349,7 +348,7 @@ class RemapperVisitor extends SimpleRemapperVisitor {
             if (isPackagePrivate(modifiers)) {
                 // Must come from the same package
                 String packageName = mapping != null ? mapping.getDeobfuscatedPackage() : inner.getPackage().getName();
-                if (packageName.equals(this.context.getPackageName())) {
+                if (!packageName.replace('/', '.').equals(this.context.getPackageName().replace('/', '.'))) {
                     continue;
                 }
             }

--- a/src/test/java/org/cadixdev/mercury/test/RemappingTests.java
+++ b/src/test/java/org/cadixdev/mercury/test/RemappingTests.java
@@ -91,6 +91,7 @@ class RemappingTests {
         // Run Mercury
         final Mercury mercury = new Mercury();
         mercury.getProcessors().add(MercuryRemapper.create(mappings));
+        mercury.setFlexibleAnonymousClassMemberLookups(true);
         mercury.rewrite(in, out);
 
         // Check that the output is as expected


### PR DESCRIPTION
If a method parameter mapping exists which will conflict with an
existing local variable after remap, Mercury will now adjust that local
variable name by appending a number (starting from 1) to the name of the
local variable.

This commit attempts to fix local variables defined in the method itself
as well as any local variables defined in lambda expressions contained
by said methods.

---

I've pushed a couple more commits, one is a simple misc fix in `AccessTransformerRewriter`, and the other is another fix related to param mapping.

---

Okay I added another commit which fixes a quirk with inner class remapping.

---

And last commit fixes an issue with implicit imports of package-private inner classes of super classes.