### PR TITLE
Overhaul unit tests

### DIFF
--- a/src/test/java/org/cadixdev/mercury/test/Java10Tests.java
+++ b/src/test/java/org/cadixdev/mercury/test/Java10Tests.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2018 Cadix Development (https://www.cadixdev.org)
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which accompanies this distribution,
+ * and is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.cadixdev.mercury.test;
+
+import org.cadixdev.mercury.Mercury;
+import org.eclipse.jdt.core.JavaCore;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class Java10Tests {
+
+    @Test
+    @DisplayName("doesn't remove var keyword (remapped type)")
+    void remapVarKeywordRemappedType() throws Exception {
+        new RemapperTest("java-10", Java10Tests::configureMercury)
+                .copy("a")
+                .register("b", "b")
+                .test();
+    }
+    @Test
+    @DisplayName("doesn't remove var keyword (not remapped type)")
+    void remapVarKeywordNotRemappedType() throws Exception {
+        new RemapperTest("java-10", Java10Tests::configureMercury)
+                .register("c", "c")
+                .test();
+    }
+
+    static void configureMercury(final Mercury mercury) {
+        mercury.setSourceCompatibility(JavaCore.VERSION_10);
+    }
+
+}

--- a/src/test/java/org/cadixdev/mercury/test/Java11Tests.java
+++ b/src/test/java/org/cadixdev/mercury/test/Java11Tests.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2018 Cadix Development (https://www.cadixdev.org)
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which accompanies this distribution,
+ * and is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.cadixdev.mercury.test;
+
+import org.cadixdev.mercury.Mercury;
+import org.eclipse.jdt.core.JavaCore;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class Java11Tests {
+
+    @Test
+    @DisplayName("doesn't remove var keyword in lambda parameter (remapped type)")
+    void remapVarKeywordRemappedTypeLambdaParameter() throws Exception {
+        new RemapperTest("java-11", Java11Tests::configureMercury)
+                .copy("a")
+                .register("b", "b")
+                .test();
+    }
+    @Test
+    @DisplayName("doesn't remove var keyword in lambda parameter (not remapped type)")
+    void remapVarKeywordNotRemappedTypeLambdaParameter() throws Exception {
+        new RemapperTest("java-11", Java11Tests::configureMercury)
+                .register("c", "c")
+                .test();
+    }
+
+    static void configureMercury(final Mercury mercury) {
+        mercury.setSourceCompatibility(JavaCore.VERSION_11);
+    }
+
+}

--- a/src/test/java/org/cadixdev/mercury/test/RemapperTest.java
+++ b/src/test/java/org/cadixdev/mercury/test/RemapperTest.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright (c) 2018 Cadix Development (https://www.cadixdev.org)
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which accompanies this distribution,
+ * and is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.cadixdev.mercury.test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.cadixdev.bombe.util.ByteStreams;
+import org.cadixdev.lorenz.MappingSet;
+import org.cadixdev.lorenz.io.MappingFormats;
+import org.cadixdev.lorenz.io.MappingsReader;
+import org.cadixdev.mercury.Mercury;
+import org.cadixdev.mercury.remapper.MercuryRemapper;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.Consumer;
+
+public class RemapperTest {
+
+    private final String name;
+    private final Consumer<Mercury> mercuryConfigure;
+
+    private final Path dir;
+    private final MappingSet mappings;
+
+    private final Map<String, String> expected = new HashMap<>();
+
+    public RemapperTest(final String name) throws IOException {
+        this(name, mercury -> {});
+    }
+
+    public RemapperTest(final String name, final Consumer<Mercury> mercuryConfigure) throws IOException {
+        this.name = name;
+        this.mercuryConfigure = mercuryConfigure;
+
+        // Create temporary directory, as Mercury needs to operate on the actual file
+        // system.
+        this.dir = Files.createTempDirectory("mercury-test");
+        Files.createDirectories(this.dir.resolve("a"));
+        Files.createDirectories(this.dir.resolve("b"));
+
+        // Read test mappings
+        this.mappings = MappingSet.create();
+        try (final MappingsReader reader = MappingFormats.byId("jam")
+                .createReader(RemapperTest.class.getResourceAsStream("/" + this.name + "/test.jam"))) {
+            reader.read(this.mappings);
+        }
+    }
+
+    public RemapperTest copy(final String file) throws IOException {
+        final Path path = this.dir.resolve("a").resolve(file + ".java");
+
+        // Make sure the parent directory exists
+        Files.createDirectories(path.getParent());
+
+        // Copy the file to the file system
+        Files.copy(
+                RemapperTest.class.getResourceAsStream("/" + this.name + "/a/" + file + ".java"),
+                path,
+                StandardCopyOption.REPLACE_EXISTING
+        );
+
+        // Finally verify the file exists, to prevent issues later on
+        assertTrue(Files.exists(path), file + " failed to copy!");
+
+        return this;
+    }
+
+    public RemapperTest register(final String a, final String b) throws IOException {
+        // Copy to a
+        this.copy(a);
+
+        // Register test
+        this.expected.put(a + ".java", b + ".java");
+
+        return this;
+    }
+
+    public void test() throws Exception {
+        final Path in = this.dir.resolve("a");
+        final Path out = this.dir.resolve("b");
+
+        final Mercury mercury = new Mercury();
+        this.mercuryConfigure.accept(mercury);
+        mercury.getProcessors().add(MercuryRemapper.create(this.mappings));
+        mercury.rewrite(in, out);
+
+        for (final String file : this.expected.values()) {
+            final Path path = out.resolve(file);
+
+            // First check the path exists
+            assertTrue(Files.exists(path), file + " doesn't exists!");
+
+            // Check the file matches the expected output
+            final String expected;
+            try (final InputStream is = RemapperTest.class.getResourceAsStream("/" + this.name + "/b/" + file)) {
+                final ByteArrayOutputStream baos = new ByteArrayOutputStream();
+                ByteStreams.copy(is, baos);
+                expected = baos.toString();
+            }
+            final String actual = new String(Files.readAllBytes(path));
+            assertEquals(expected, actual, "Remapped code for " + file + " does not match expected");
+        }
+    }
+
+}

--- a/src/test/java/org/cadixdev/mercury/test/RemappingTests.java
+++ b/src/test/java/org/cadixdev/mercury/test/RemappingTests.java
@@ -20,6 +20,7 @@ import org.cadixdev.lorenz.io.MappingsReader;
 import org.cadixdev.mercury.Mercury;
 import org.cadixdev.mercury.remapper.MercuryRemapper;
 import org.eclipse.jdt.core.JavaCore;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 import java.io.ByteArrayOutputStream;
@@ -32,6 +33,134 @@ import java.nio.file.StandardCopyOption;
 import java.util.Comparator;
 
 class RemappingTests {
+
+    @Test
+    @DisplayName("remaps class declaration")
+    void remapClassDeclaration() throws Exception {
+        new RemapperTest("remap-class")
+                .register("a", "Declaration")
+                .test();
+    }
+
+    @Test
+    @DisplayName("remaps field type")
+    void remapFieldType() throws Exception {
+        new RemapperTest("remap-class")
+                .copy("a")
+                .register("b", "b")
+                .test();
+    }
+
+    @Test
+    @DisplayName("remaps method type")
+    void remapMethodType() throws Exception {
+        new RemapperTest("remap-class")
+                .copy("a")
+                .register("c", "c")
+                .test();
+    }
+
+    @Test
+    @DisplayName("remaps method declaration")
+    void remapMethodDeclaration() throws Exception {
+        new RemapperTest("remap-method")
+                .register("a", "a")
+                .test();
+    }
+
+    @Test
+    @DisplayName("remaps method call")
+    void remapMethodCall() throws Exception {
+        new RemapperTest("remap-method")
+                .copy("a")
+                .register("b", "b")
+                .test();
+    }
+
+    @Test
+    @DisplayName("remaps field declaration")
+    void remapFieldDeclaration() throws Exception {
+        new RemapperTest("remap-field")
+                .register("a", "a")
+                .test();
+    }
+
+    @Test
+    @DisplayName("remaps field usage")
+    void remapFieldUsage() throws Exception {
+        new RemapperTest("remap-field")
+                .copy("a")
+                .register("b", "b")
+                .test();
+    }
+
+    @Test
+    @DisplayName("remaps enum constant declaration")
+    void remapEnumConstantDeclaration() throws Exception {
+        new RemapperTest("remap-field")
+                .register("c", "c")
+                .test();
+    }
+
+    @Test
+    @DisplayName("remaps enum constant usage")
+    void remapEnumConstantUsage() throws Exception {
+        new RemapperTest("remap-field")
+                .copy("c")
+                .register("d", "d")
+                .test();
+    }
+
+    @Test
+    @DisplayName("remaps single method parameter")
+    void remapSingleParameter() throws Exception {
+        new RemapperTest("remap-param")
+                .register("a", "a")
+                .test();
+    }
+
+    @Test
+    @DisplayName("remaps multiple method parameters")
+    void remapMultipleParameters() throws Exception {
+        new RemapperTest("remap-param")
+                .register("b", "b")
+                .test();
+    }
+
+    @Test
+    @DisplayName("remaps class reference in javadocs")
+    void remapJavadocClassReference() throws Exception {
+        new RemapperTest("remap-javadocs")
+                .copy("a")
+                .register("b", "b")
+                .test();
+    }
+
+    @Test
+    @DisplayName("remaps field reference in javadocs")
+    void remapJavadocFieldReference() throws Exception {
+        new RemapperTest("remap-javadocs")
+                .copy("a")
+                .register("c", "c")
+                .test();
+    }
+
+    @Test
+    @DisplayName("remaps method reference in javadocs")
+    void remapJavadocMethodReference() throws Exception {
+        new RemapperTest("remap-javadocs")
+                .copy("a")
+                .register("d", "d")
+                .test();
+    }
+
+    @Test
+    @DisplayName("remaps parameter reference in javadocs")
+    void remapJavadocParamReference() throws Exception {
+        new RemapperTest("remap-javadocs")
+                .register("e", "e")
+                .test();
+    }
 
     // Mercury contains the following tests:
     // 1. Simple remaps

--- a/src/test/resources/java-10/a/a.java
+++ b/src/test/resources/java-10/a/a.java
@@ -1,0 +1,12 @@
+/*
+ * Copyright (c) 2018 Cadix Development (https://www.cadixdev.org)
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which accompanies this distribution,
+ * and is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+public class a {
+}

--- a/src/test/resources/java-10/a/b.java
+++ b/src/test/resources/java-10/a/b.java
@@ -1,0 +1,15 @@
+/*
+ * Copyright (c) 2018 Cadix Development (https://www.cadixdev.org)
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which accompanies this distribution,
+ * and is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+public class b {
+    public static void main(final String[] args) {
+        final var instance = new a();
+    }
+}

--- a/src/test/resources/java-10/a/c.java
+++ b/src/test/resources/java-10/a/c.java
@@ -1,0 +1,15 @@
+/*
+ * Copyright (c) 2018 Cadix Development (https://www.cadixdev.org)
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which accompanies this distribution,
+ * and is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+public class c {
+    public static void main(final String[] args) {
+        final var name = "Demo Name";
+    }
+}

--- a/src/test/resources/java-10/b/Remapped.java
+++ b/src/test/resources/java-10/b/Remapped.java
@@ -1,0 +1,12 @@
+/*
+ * Copyright (c) 2018 Cadix Development (https://www.cadixdev.org)
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which accompanies this distribution,
+ * and is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+public class Remapped {
+}

--- a/src/test/resources/java-10/b/b.java
+++ b/src/test/resources/java-10/b/b.java
@@ -1,0 +1,15 @@
+/*
+ * Copyright (c) 2018 Cadix Development (https://www.cadixdev.org)
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which accompanies this distribution,
+ * and is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+public class b {
+    public static void main(final String[] args) {
+        final var instance = new Remapped();
+    }
+}

--- a/src/test/resources/java-10/b/c.java
+++ b/src/test/resources/java-10/b/c.java
@@ -1,0 +1,15 @@
+/*
+ * Copyright (c) 2018 Cadix Development (https://www.cadixdev.org)
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which accompanies this distribution,
+ * and is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+public class c {
+    public static void main(final String[] args) {
+        final var name = "Demo Name";
+    }
+}

--- a/src/test/resources/java-10/test.jam
+++ b/src/test/resources/java-10/test.jam
@@ -1,0 +1,1 @@
+CL a Remapped

--- a/src/test/resources/java-11/a/a.java
+++ b/src/test/resources/java-11/a/a.java
@@ -1,0 +1,12 @@
+/*
+ * Copyright (c) 2018 Cadix Development (https://www.cadixdev.org)
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which accompanies this distribution,
+ * and is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+public class a {
+}

--- a/src/test/resources/java-11/a/b.java
+++ b/src/test/resources/java-11/a/b.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) 2018 Cadix Development (https://www.cadixdev.org)
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which accompanies this distribution,
+ * and is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+import java.util.function.Consumer;
+
+public class b {
+    public static void main(final String[] args) {
+        using(new a(), (var instance) -> {
+        });
+    }
+
+    private static void using(final a instance, final Consumer<a> consumer) {
+        consumer.accept(instance);
+    }
+}

--- a/src/test/resources/java-11/a/c.java
+++ b/src/test/resources/java-11/a/c.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) 2018 Cadix Development (https://www.cadixdev.org)
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which accompanies this distribution,
+ * and is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+import java.util.function.Consumer;
+
+public class b {
+    public static void main(final String[] args) {
+        using("Demo", (var name) -> {
+        });
+    }
+
+    private static void using(final String name, final Consumer<String> consumer) {
+        consumer.accept(name);
+    }
+}

--- a/src/test/resources/java-11/b/Remapped.java
+++ b/src/test/resources/java-11/b/Remapped.java
@@ -1,0 +1,12 @@
+/*
+ * Copyright (c) 2018 Cadix Development (https://www.cadixdev.org)
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which accompanies this distribution,
+ * and is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+public class Remapped {
+}

--- a/src/test/resources/java-11/b/b.java
+++ b/src/test/resources/java-11/b/b.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) 2018 Cadix Development (https://www.cadixdev.org)
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which accompanies this distribution,
+ * and is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+import java.util.function.Consumer;
+
+public class b {
+    public static void main(final String[] args) {
+        using(new Remapped(), (var instance) -> {
+        });
+    }
+
+    private static void using(final Remapped instance, final Consumer<Remapped> consumer) {
+        consumer.accept(instance);
+    }
+}

--- a/src/test/resources/java-11/b/c.java
+++ b/src/test/resources/java-11/b/c.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) 2018 Cadix Development (https://www.cadixdev.org)
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which accompanies this distribution,
+ * and is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+import java.util.function.Consumer;
+
+public class b {
+    public static void main(final String[] args) {
+        using("Demo", (var name) -> {
+        });
+    }
+
+    private static void using(final String name, final Consumer<String> consumer) {
+        consumer.accept(name);
+    }
+}

--- a/src/test/resources/java-11/test.jam
+++ b/src/test/resources/java-11/test.jam
@@ -1,0 +1,1 @@
+CL a Remapped

--- a/src/test/resources/remap-class/a/a.java
+++ b/src/test/resources/remap-class/a/a.java
@@ -1,0 +1,12 @@
+/*
+ * Copyright (c) 2018 Cadix Development (https://www.cadixdev.org)
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which accompanies this distribution,
+ * and is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+public class a {
+}

--- a/src/test/resources/remap-class/a/b.java
+++ b/src/test/resources/remap-class/a/b.java
@@ -1,0 +1,17 @@
+/*
+ * Copyright (c) 2018 Cadix Development (https://www.cadixdev.org)
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which accompanies this distribution,
+ * and is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+public class b {
+    private a a;
+
+    public b(final a a) {
+        this.a = a;
+    }
+}

--- a/src/test/resources/remap-class/a/c.java
+++ b/src/test/resources/remap-class/a/c.java
@@ -1,0 +1,14 @@
+/*
+ * Copyright (c) 2018 Cadix Development (https://www.cadixdev.org)
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which accompanies this distribution,
+ * and is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+public class c {
+    void a(final a a) {
+    }
+}

--- a/src/test/resources/remap-class/b/Declaration.java
+++ b/src/test/resources/remap-class/b/Declaration.java
@@ -1,0 +1,12 @@
+/*
+ * Copyright (c) 2018 Cadix Development (https://www.cadixdev.org)
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which accompanies this distribution,
+ * and is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+public class Declaration {
+}

--- a/src/test/resources/remap-class/b/b.java
+++ b/src/test/resources/remap-class/b/b.java
@@ -1,0 +1,17 @@
+/*
+ * Copyright (c) 2018 Cadix Development (https://www.cadixdev.org)
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which accompanies this distribution,
+ * and is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+public class b {
+    private Declaration a;
+
+    public b(final Declaration a) {
+        this.a = a;
+    }
+}

--- a/src/test/resources/remap-class/b/c.java
+++ b/src/test/resources/remap-class/b/c.java
@@ -1,0 +1,14 @@
+/*
+ * Copyright (c) 2018 Cadix Development (https://www.cadixdev.org)
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which accompanies this distribution,
+ * and is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+public class c {
+    void a(final Declaration a) {
+    }
+}

--- a/src/test/resources/remap-class/test.jam
+++ b/src/test/resources/remap-class/test.jam
@@ -1,0 +1,1 @@
+CL a Declaration

--- a/src/test/resources/remap-field/a/a.java
+++ b/src/test/resources/remap-field/a/a.java
@@ -1,0 +1,13 @@
+/*
+ * Copyright (c) 2018 Cadix Development (https://www.cadixdev.org)
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which accompanies this distribution,
+ * and is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+public class a {
+    public String a;
+}

--- a/src/test/resources/remap-field/a/b.java
+++ b/src/test/resources/remap-field/a/b.java
@@ -1,0 +1,16 @@
+/*
+ * Copyright (c) 2018 Cadix Development (https://www.cadixdev.org)
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which accompanies this distribution,
+ * and is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+public class b {
+    public static void main(final String[] args) {
+        final a instance = new a();
+        System.out.println(instance.a);
+    }
+}

--- a/src/test/resources/remap-field/a/c.java
+++ b/src/test/resources/remap-field/a/c.java
@@ -1,0 +1,15 @@
+/*
+ * Copyright (c) 2018 Cadix Development (https://www.cadixdev.org)
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which accompanies this distribution,
+ * and is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+public enum c {
+    a,
+    b,
+    ;
+}

--- a/src/test/resources/remap-field/a/d.java
+++ b/src/test/resources/remap-field/a/d.java
@@ -1,0 +1,16 @@
+/*
+ * Copyright (c) 2018 Cadix Development (https://www.cadixdev.org)
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which accompanies this distribution,
+ * and is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+public class d {
+    public static void main(final String[] args) {
+        System.out.println(c.a.toString());
+        System.out.println(c.b.toString());
+    }
+}

--- a/src/test/resources/remap-field/b/a.java
+++ b/src/test/resources/remap-field/b/a.java
@@ -1,0 +1,13 @@
+/*
+ * Copyright (c) 2018 Cadix Development (https://www.cadixdev.org)
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which accompanies this distribution,
+ * and is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+public class a {
+    public String name;
+}

--- a/src/test/resources/remap-field/b/b.java
+++ b/src/test/resources/remap-field/b/b.java
@@ -1,0 +1,16 @@
+/*
+ * Copyright (c) 2018 Cadix Development (https://www.cadixdev.org)
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which accompanies this distribution,
+ * and is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+public class b {
+    public static void main(final String[] args) {
+        final a instance = new a();
+        System.out.println(instance.name);
+    }
+}

--- a/src/test/resources/remap-field/b/c.java
+++ b/src/test/resources/remap-field/b/c.java
@@ -1,0 +1,15 @@
+/*
+ * Copyright (c) 2018 Cadix Development (https://www.cadixdev.org)
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which accompanies this distribution,
+ * and is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+public enum c {
+    FIRST,
+    SECOND,
+    ;
+}

--- a/src/test/resources/remap-field/b/d.java
+++ b/src/test/resources/remap-field/b/d.java
@@ -1,0 +1,16 @@
+/*
+ * Copyright (c) 2018 Cadix Development (https://www.cadixdev.org)
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which accompanies this distribution,
+ * and is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+public class d {
+    public static void main(final String[] args) {
+        System.out.println(c.FIRST.toString());
+        System.out.println(c.SECOND.toString());
+    }
+}

--- a/src/test/resources/remap-field/test.jam
+++ b/src/test/resources/remap-field/test.jam
@@ -1,0 +1,4 @@
+FD a a Ljava/lang/String; name
+
+FD c a Lc; FIRST
+FD c b Lc; SECOND

--- a/src/test/resources/remap-javadocs/a/a.java
+++ b/src/test/resources/remap-javadocs/a/a.java
@@ -1,0 +1,16 @@
+/*
+ * Copyright (c) 2018 Cadix Development (https://www.cadixdev.org)
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which accompanies this distribution,
+ * and is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+public class a {
+    public String a;
+
+    void b() {
+    }
+}

--- a/src/test/resources/remap-javadocs/a/b.java
+++ b/src/test/resources/remap-javadocs/a/b.java
@@ -1,0 +1,17 @@
+/*
+ * Copyright (c) 2018 Cadix Development (https://www.cadixdev.org)
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which accompanies this distribution,
+ * and is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+public class b {
+    /**
+     * {@link a}
+     */
+    void demo() {
+    }
+}

--- a/src/test/resources/remap-javadocs/a/c.java
+++ b/src/test/resources/remap-javadocs/a/c.java
@@ -1,0 +1,17 @@
+/*
+ * Copyright (c) 2018 Cadix Development (https://www.cadixdev.org)
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which accompanies this distribution,
+ * and is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+public class c {
+    /**
+     * {@link a#a}
+     */
+    void demo() {
+    }
+}

--- a/src/test/resources/remap-javadocs/a/d.java
+++ b/src/test/resources/remap-javadocs/a/d.java
@@ -1,0 +1,17 @@
+/*
+ * Copyright (c) 2018 Cadix Development (https://www.cadixdev.org)
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which accompanies this distribution,
+ * and is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+public class d {
+    /**
+     * {@link a#b()}
+     */
+    void demo() {
+    }
+}

--- a/src/test/resources/remap-javadocs/a/e.java
+++ b/src/test/resources/remap-javadocs/a/e.java
@@ -1,0 +1,17 @@
+/*
+ * Copyright (c) 2018 Cadix Development (https://www.cadixdev.org)
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which accompanies this distribution,
+ * and is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+public class e {
+    /**
+     * @param a
+     */
+    void a(final String a) {
+    }
+}

--- a/src/test/resources/remap-javadocs/b/Remapped.java
+++ b/src/test/resources/remap-javadocs/b/Remapped.java
@@ -1,0 +1,16 @@
+/*
+ * Copyright (c) 2018 Cadix Development (https://www.cadixdev.org)
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which accompanies this distribution,
+ * and is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+public class Remapped {
+    public String name;
+
+    void run() {
+    }
+}

--- a/src/test/resources/remap-javadocs/b/b.java
+++ b/src/test/resources/remap-javadocs/b/b.java
@@ -1,0 +1,17 @@
+/*
+ * Copyright (c) 2018 Cadix Development (https://www.cadixdev.org)
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which accompanies this distribution,
+ * and is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+public class b {
+    /**
+     * {@link Remapped}
+     */
+    void demo() {
+    }
+}

--- a/src/test/resources/remap-javadocs/b/c.java
+++ b/src/test/resources/remap-javadocs/b/c.java
@@ -1,0 +1,17 @@
+/*
+ * Copyright (c) 2018 Cadix Development (https://www.cadixdev.org)
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which accompanies this distribution,
+ * and is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+public class c {
+    /**
+     * {@link Remapped#name}
+     */
+    void demo() {
+    }
+}

--- a/src/test/resources/remap-javadocs/b/d.java
+++ b/src/test/resources/remap-javadocs/b/d.java
@@ -1,0 +1,17 @@
+/*
+ * Copyright (c) 2018 Cadix Development (https://www.cadixdev.org)
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which accompanies this distribution,
+ * and is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+public class d {
+    /**
+     * {@link Remapped#run()}
+     */
+    void demo() {
+    }
+}

--- a/src/test/resources/remap-javadocs/b/e.java
+++ b/src/test/resources/remap-javadocs/b/e.java
@@ -1,0 +1,17 @@
+/*
+ * Copyright (c) 2018 Cadix Development (https://www.cadixdev.org)
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which accompanies this distribution,
+ * and is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+public class e {
+    /**
+     * @param group
+     */
+    void a(final String group) {
+    }
+}

--- a/src/test/resources/remap-javadocs/test.jam
+++ b/src/test/resources/remap-javadocs/test.jam
@@ -1,0 +1,7 @@
+CL a Remapped
+
+FD a a Ljava/lang/String; name
+
+MD a b ()V; run
+
+MP e a (Ljava/lang/String;)V 0 group

--- a/src/test/resources/remap-method/a/a.java
+++ b/src/test/resources/remap-method/a/a.java
@@ -1,0 +1,14 @@
+/*
+ * Copyright (c) 2018 Cadix Development (https://www.cadixdev.org)
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which accompanies this distribution,
+ * and is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+public class a {
+    public void a() {
+    }
+}

--- a/src/test/resources/remap-method/a/b.java
+++ b/src/test/resources/remap-method/a/b.java
@@ -1,0 +1,16 @@
+/*
+ * Copyright (c) 2018 Cadix Development (https://www.cadixdev.org)
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which accompanies this distribution,
+ * and is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+public class b {
+    public static void main(final String[] args) {
+        final a instance = new a();
+        a.a();
+    }
+}

--- a/src/test/resources/remap-method/b/a.java
+++ b/src/test/resources/remap-method/b/a.java
@@ -1,0 +1,14 @@
+/*
+ * Copyright (c) 2018 Cadix Development (https://www.cadixdev.org)
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which accompanies this distribution,
+ * and is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+public class a {
+    public void run() {
+    }
+}

--- a/src/test/resources/remap-method/b/b.java
+++ b/src/test/resources/remap-method/b/b.java
@@ -1,0 +1,16 @@
+/*
+ * Copyright (c) 2018 Cadix Development (https://www.cadixdev.org)
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which accompanies this distribution,
+ * and is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+public class b {
+    public static void main(final String[] args) {
+        final a instance = new a();
+        a.run();
+    }
+}

--- a/src/test/resources/remap-method/test.jam
+++ b/src/test/resources/remap-method/test.jam
@@ -1,0 +1,1 @@
+MD a a ()V; run

--- a/src/test/resources/remap-param/a/a.java
+++ b/src/test/resources/remap-param/a/a.java
@@ -1,0 +1,15 @@
+/*
+ * Copyright (c) 2018 Cadix Development (https://www.cadixdev.org)
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which accompanies this distribution,
+ * and is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+public class a {
+    void a(final String a) {
+        System.out.println(a);
+    }
+}

--- a/src/test/resources/remap-param/a/b.java
+++ b/src/test/resources/remap-param/a/b.java
@@ -1,0 +1,16 @@
+/*
+ * Copyright (c) 2018 Cadix Development (https://www.cadixdev.org)
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which accompanies this distribution,
+ * and is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+public class b {
+    void a(final String a, final String b) {
+        System.out.println(a);
+        System.out.println(b);
+    }
+}

--- a/src/test/resources/remap-param/b/a.java
+++ b/src/test/resources/remap-param/b/a.java
@@ -1,0 +1,15 @@
+/*
+ * Copyright (c) 2018 Cadix Development (https://www.cadixdev.org)
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which accompanies this distribution,
+ * and is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+public class a {
+    void a(final String name) {
+        System.out.println(name);
+    }
+}

--- a/src/test/resources/remap-param/b/b.java
+++ b/src/test/resources/remap-param/b/b.java
@@ -1,0 +1,16 @@
+/*
+ * Copyright (c) 2018 Cadix Development (https://www.cadixdev.org)
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which accompanies this distribution,
+ * and is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+public class b {
+    void a(final String id, final String name) {
+        System.out.println(id);
+        System.out.println(name);
+    }
+}

--- a/src/test/resources/remap-param/test.jam
+++ b/src/test/resources/remap-param/test.jam
@@ -1,0 +1,6 @@
+# a.java
+MP a a (Ljava/lang/String;)V 0 name
+
+# b.java
+MP b a (Ljava/lang/String;Ljava/lang/String;)V 0 id
+MP b a (Ljava/lang/String;Ljava/lang/String;)V 1 name


### PR DESCRIPTION
This begins the work to pull apart distinct unit tests for
functionality in Mercury - rather than relying on a single one, and
viewing the diffs.

This also makes it far more explicit about what is being tested, so
hopefully accidentally removing a test shouldn't be so easy.