### PR TITLE
Use latest JLS for parser

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -25,7 +25,7 @@ repositories {
     mavenCentral()
 }
 
-val jdt = "org.eclipse.jdt:org.eclipse.jdt.core:3.25.0"
+val jdt = "org.eclipse.jdt:org.eclipse.jdt.core:3.27.0"
 dependencies {
     api(jdt)
 

--- a/src/main/java/org/cadixdev/mercury/Mercury.java
+++ b/src/main/java/org/cadixdev/mercury/Mercury.java
@@ -190,7 +190,7 @@ public final class Mercury {
     }
 
     private void run() throws Exception {
-        ASTParser parser = ASTParser.newParser(AST.JLS10);
+        ASTParser parser = ASTParser.newParser(AST.getJLSLatest());
 
         // Set Java version
         Map<String, String> options = JavaCore.getOptions();

--- a/src/main/java/org/cadixdev/mercury/remapper/RemapperVisitor.java
+++ b/src/main/java/org/cadixdev/mercury/remapper/RemapperVisitor.java
@@ -39,6 +39,7 @@ import org.eclipse.jdt.core.dom.NameQualifiedType;
 import org.eclipse.jdt.core.dom.PackageDeclaration;
 import org.eclipse.jdt.core.dom.QualifiedName;
 import org.eclipse.jdt.core.dom.QualifiedType;
+import org.eclipse.jdt.core.dom.RecordDeclaration;
 import org.eclipse.jdt.core.dom.SimpleName;
 import org.eclipse.jdt.core.dom.SimpleType;
 import org.eclipse.jdt.core.dom.TagElement;
@@ -429,6 +430,12 @@ class RemapperVisitor extends SimpleRemapperVisitor {
     }
 
     @Override
+    public boolean visit(RecordDeclaration node) {
+        pushImportContext(node.resolveBinding());
+        return true;
+    }
+
+    @Override
     public boolean visit(TypeDeclaration node) {
         pushImportContext(node.resolveBinding());
         return true;
@@ -446,6 +453,11 @@ class RemapperVisitor extends SimpleRemapperVisitor {
 
     @Override
     public void endVisit(EnumDeclaration node) {
+        this.importStack.pop();
+    }
+
+    @Override
+    public void endVisit(RecordDeclaration node) {
         this.importStack.pop();
     }
 


### PR DESCRIPTION
Related to #40 

This allows basic remapping of records, in combination with setting the source compatibility level to 16. Further work looks to be needed for full remapping, however this is a good first step.